### PR TITLE
Add support for yaml format for measurement data

### DIFF
--- a/prepareCMSInputs.py
+++ b/prepareCMSInputs.py
@@ -172,3 +172,4 @@ channel_data = {
 
 for label, data in channel_data.items():
     data.writeToJSON('measurements/{}.json'.format(label))
+    data.writeToYAML('measurements/{}.yaml'.format(label))

--- a/testFit.py
+++ b/testFit.py
@@ -52,7 +52,12 @@ channel_data = dict()
 for channel in args.input:
     label, measurement_file, param_files = channel.split(':')
     print('>> Reading measurement {} and parameterisation {}'.format(measurement_file, param_files))
-    measurement = Measurement.fromJSON(measurement_file)
+    if measurement_file.split('.')[-1]=='yaml':
+      measurement = Measurement.fromYAML(measurement_file)
+    elif measurement_file.split('.')[-1]=='json':
+      measurement = Measurement.fromJSON(measurement_file)
+    else:
+      print('File format not supported')
     params = [EFTScaling.fromJSON(X) for X in param_files.split(',')]
     channel_data[label] = (measurement, params)
 

--- a/tools.py
+++ b/tools.py
@@ -1,4 +1,5 @@
 import numpy as np
+import yaml
 import json
 from math import sqrt
 
@@ -18,8 +19,14 @@ class Measurement(object):
         return cls.fromDict(input)
 
     @classmethod
+    def fromYAML(cls, filename):
+        with open(filename) as yamlfile:
+            input = yaml.load(yamlfile)
+        return cls.fromDict(input)
+
+    @classmethod
     def fromDict(cls, d):
-        return cls(nbins=d["nbins"], bin_labels=d["bin_labels"], sm=np.array(d["sm"]), bf=np.array(d["bf"]), cov=np.array(d["cov"]))
+        return cls(nbins=d["nbins"] if "nbins" in d else len(d["bin_labels"]) , bin_labels=d["bin_labels"], sm=np.array(d["sm"]), bf=np.array(d["bf"]), cov=np.array(d["cov"]))
 
     def writeToJSON(self, filename):
         with open(filename, 'w') as outfile:
@@ -31,6 +38,18 @@ class Measurement(object):
                 "cov": self.cov.tolist(),
             }
             outfile.write(json.dumps(res, sort_keys=False, indent=2))
+
+    def writeToYAML(self, filename):
+        with open(filename, 'w') as outfile:
+            res = {
+                "nbins": int(self.nbins),
+                "bin_labels": self.bin_labels,
+                "sm": self.sm.tolist(),
+                "bf": self.bf.tolist(),
+                "cov": self.cov.tolist(),
+            }
+            yaml.dump(res,outfile,default_flow_style=False, allow_unicode=True)
+
 
 
 def ReadIndependent(entry, col=0):


### PR DESCRIPTION
What this does not yet do is fully harmonise the labels in the measurements dictionary between ATLAS and CMS. I'm more or less happy to switch to their convention ("covariance" instead of "cov", "measured" instead of "bf") - except I prefer "bin_labels" or "bin_names" to just "names". For this we will need to talk to them. In principle we can now read ATLAS yaml files by just editing the keys in the dictionary. The files they have created don't have an 'nbins' parameter, which is why we set this parameter to the length of the bin_labels list in case 'nbins' doesn't exist. (partially addresses #3)